### PR TITLE
feature var "kafka_download_url"

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-kafka_version: 3.7.0
+kafka_version: 3.6.0
 kafka_scala_version: 2.13
 kafka_openjdk_version: 17
 kafka_download_url: https://archive.apache.org/dist/kafka/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -2,7 +2,7 @@
 kafka_version: 3.7.0
 kafka_scala_version: 2.13
 kafka_openjdk_version: 17
-kafka_download_url: https://dlcdn.apache.org/kafka/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz
+kafka_download_url: https://archive.apache.org/dist/kafka/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz
 # must be defined as same as ansible inventory group
 kafka_hosts_group: kafka
 kafka_user: kafka


### PR DESCRIPTION
Чтобы не приходилось каждый раз исправлять версию образа кафки и вешать новый тег, сделал ссылку для скачивания образа более универсальной

Проверил локально, версия 3.6.0 скачалась и запустилась:
<img width="951" alt="image" src="https://github.com/m-shalenko/ansible-role-kafka/assets/62985982/3505b2c1-96d0-4ba5-a290-db05460bffec">

<img width="1440" alt="image" src="https://github.com/m-shalenko/ansible-role-kafka/assets/62985982/a3897ab4-c29a-4f24-b658-75f766eb7e68">
